### PR TITLE
Added weapon optics ui to pistols/snipers

### DIFF
--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_dmr.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_dmr.txt
@@ -11,5 +11,25 @@
 		econ
 		{
 		}
+		stabilizer
+		{
+			"zoom_fov"		"35"
+			"ui5_enable"		"1"
+			"threat_scope_enabled"		"1"
+			"threat_scope_bounds_tagname1"	"SCR_TR_ORACLE"
+			"threat_scope_bounds_tagname2"	"SCR_BL_ORACLE"
+		}
+	}
+	//Oracle/stabilizer blue dot
+	"ui5_enable"		"0"
+	"ui5_draw_cloaked"	"1"
+	UiData5
+	{
+		"ui"								"ui/volt_sights"
+		"mesh"							"models/weapons/attachments/oracle_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
 	}
 }

--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_doubletake.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_doubletake.txt
@@ -6,4 +6,33 @@
 	//"regen_ammo_refill_rate"						"1.0"
 	//"regen_ammo_stockpile_max_fraction"				"0.1"
 	//"regen_ammo_stockpile_drain_rate_when_charging"	"0.0"
+	
+	Mods
+	{
+		stabilizer
+		{
+			"ui1_enable"		"0"
+			"ui2_enable"		"1"
+			"ui3_enable"		"0"
+			"ui4_enable"		"0"
+			"ui5_enable"		"1"
+			"zoom_fov"		"35"
+			"threat_scope_enabled"		"1"
+			"threat_scope_bounds_tagname1"	"SCR_TR_ORACLE"
+			"threat_scope_bounds_tagname2"	"SCR_BL_ORACLE"
+		}
+	}
+
+	//Oracle/stabilizer blue dot
+	"ui5_enable"		"0"
+	"ui5_draw_cloaked"	"1"
+	UiData5
+	{
+		"ui"								"ui/volt_sights"
+		"mesh"							"models/weapons/attachments/oracle_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
+	}
 }

--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_shotgun_pistol.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_shotgun_pistol.txt
@@ -1,0 +1,92 @@
+#base "_base_pistol.txt"
+#base "_base_projectile.txt"
+WeaponData
+{
+	Mods
+	{
+		hcog
+		{
+			"ui1_enable"		"0"
+			"ui3_enable"		"0"
+			"ui4_enable"		"0"
+			"ui5_enable"		"1"
+
+			"viewmodel_offset_ads"							"0 -.7 -0.79" //"0 -6 -0.79"
+			"zoom_fov"										"35"
+			"dof_zoom_nearDepthStart"						"9.161" //"0.750"
+			"dof_zoom_nearDepthEnd"							"15.204" //"8.000"
+		}
+		threat_scope
+		{
+			"ui1_enable"		"0"
+			"ui3_enable"		"0"
+			"ui4_enable"		"1"
+			"ui5_enable"		"0"
+
+			"zoom_fov"										"35"
+			"viewmodel_offset_ads"							"0 -3 -0.83"
+			"dof_zoom_nearDepthStart"						"7.491" //"5.040"
+			"dof_zoom_nearDepthEnd"							"12.545" //"5.737"
+		}
+		redline_sight
+		{
+			"ui1_enable"		"0"
+			"ui3_enable"		"1"
+			"ui4_enable"		"0"
+			"ui5_enable"		"0"
+			"ui6_enable"		"0"
+
+			"bodygroup3_set"	"0"
+			"bodygroup4_set"	"1"
+			"bodygroup5_set"	"0"
+			"viewmodel_offset_ads"							"0 -3 -0.795"
+			"zoom_fov"										"25"
+
+			"dof_zoom_nearDepthStart"						"8.491"
+			"dof_zoom_nearDepthEnd"							"13.945"
+
+			//threat settings
+			//"threat_scope_enabled"			"1"
+			//"threat_scope_bounds_tagname1"	"SCR_TR_ACGS"
+			//"threat_scope_bounds_tagname2"	"SCR_BL_ACGS"
+		}
+	}
+	//Acog
+	"ui3_enable"		"0"
+	"ui3_draw_cloaked"	"1"
+	UiData3
+	{
+		"ui"								"ui/acgs_redline"
+		"mesh"							"models/weapons/attachments/acgs_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+			ammo						weapon_ammo
+			clipSize						weapon_clipSize
+		}
+	}
+	//threat
+	"ui4_enable"		"0"
+	"ui4_draw_cloaked"	"1"
+	UiData4
+	{
+		"ui"							"ui/cro_threat_front"
+		"mesh"					"models/weapons/attachments/cro_rui_upper"
+		Args
+		{
+			zoomFrac					player_zoomfrac
+		}
+	}
+	//hcog
+	"ui5_enable"		"0"
+	"ui5_draw_cloaked"	"1"
+	UiData5
+	{
+		"ui"								"ui/vinson_sights"
+		"mesh"						"models/weapons/attachments/cqh_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
+	}
+}

--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_sniper.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_sniper.txt
@@ -6,5 +6,27 @@
 	//"regen_ammo_refill_rate"						"1.0"
 	//"regen_ammo_stockpile_max_fraction"				"0.1"
 	//"regen_ammo_stockpile_drain_rate_when_charging"	"0.0"
-
+	Mods
+	{
+		stabilizer
+		{
+			"zoom_fov"		"35"
+			"ui5_enable"		"1"
+			"threat_scope_enabled"		"1"
+			"threat_scope_bounds_tagname1"	"SCR_TR_ORACLE"
+			"threat_scope_bounds_tagname2"	"SCR_BL_ORACLE"
+		}
+	}
+	//Oracle/stabilizer blue dot
+	"ui5_enable"		"0"
+	"ui5_draw_cloaked"	"1"
+	UiData5
+	{
+		"ui"								"ui/volt_sights"
+		"mesh"							"models/weapons/attachments/oracle_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
+	}
 }

--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_wingman.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_wingman.txt
@@ -12,5 +12,83 @@ WeaponData
         {
             "ammo_clip_size"            "*0.166"
         }
+		hcog
+		{
+			"ui3_enable"	"0"
+			"ui4_enable"	"0"
+			"ui5_enable"	"0"
+			"ui6_enable"	"1"
+
+			"viewmodel_offset_ads"							"0 -.7 -0.75" //"0 -6.7 -0.75"
+			"dof_zoom_nearDepthStart"						"9.161" //"6.161"
+			"dof_zoom_nearDepthEnd"							"15.204" //"9.204"
+		}
+		redline_sight
+		{
+			"ui3_enable"	"1"
+			"ui4_enable"	"0"
+			"ui5_enable"	"0"
+			"ui6_enable"	"0"
+
+			"viewmodel_offset_ads"							"0 -3 -0.755" //"0 -9 -0.78"
+			"zoom_fov"										"25"
+			"dof_zoom_nearDepthStart"						"8.491" //"4.491"
+			"dof_zoom_nearDepthEnd"							"12.945" //"5.545"
+
+			//threat settings
+			//"threat_scope_enabled"			"1"
+			//"threat_scope_bounds_tagname1"	"SCR_TR_ACGS"
+			//"threat_scope_bounds_tagname2"	"SCR_BL_ACGS"
+		}
+		threat_scope
+		{
+			"ui3_enable"	"0"
+			"ui4_enable"	"1"
+			"ui5_enable"	"0"
+			"ui6_enable"	"0"
+
+			"viewmodel_offset_ads"							"0 -3 -0.78" //"0 -9 -0.78"
+			"zoom_fov"										"35"
+			"dof_zoom_nearDepthStart"						"7.491" //"4.491"
+			"dof_zoom_nearDepthEnd"							"12.545" //"5.545"
+		}
     }
+	//Acog
+	"ui3_enable"		"0"
+	"ui3_draw_cloaked"	"1"
+	UiData3
+	{
+		"ui"								"ui/acgs_redline"
+		"mesh"							"models/weapons/attachments/acgs_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+			ammo						weapon_ammo
+			clipSize						weapon_clipSize
+		}
+	}
+	//threat
+	"ui4_enable"		"0"
+	"ui4_draw_cloaked"	"1"
+	UiData4
+	{
+		"ui"							"ui/cro_threat_front"
+		"mesh"					"models/weapons/attachments/cro_rui_upper"
+		Args
+		{
+			zoomFrac					player_zoomfrac
+		}
+	}
+	//hcog
+	"ui6_enable"		"0"
+	"ui6_draw_cloaked"	"1"
+	UiData6
+	{
+		"ui"								"ui/vinson_sights"
+		"mesh"						"models/weapons/attachments/cqh_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
+	}
 }

--- a/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_wingman_n.txt
+++ b/mods/EladNLG.Roguelike/keyvalues/scripts/weapons/mp_weapon_wingman_n.txt
@@ -1,0 +1,84 @@
+#base "_base_pistol.txt"
+WeaponData
+{
+	Mods
+	{
+		hcog
+		{
+			"ui3_enable"		"0"
+			"ui4_enable"		"0"
+			"ui5_enable"		"1"
+			"ui6_enable"		"0"
+			"viewmodel_offset_ads"							"0 -.7 -0.55" //"0 -6.7 -0.75"
+			"zoom_fov"										"35"
+			"anim_alt_idleAttack"	"1"
+			"dof_zoom_nearDepthStart"						"9.161"
+			"dof_zoom_nearDepthEnd"							"15.204"
+		}
+		redline_sight
+		{
+			"ui3_enable"		"1"
+			"ui4_enable"		"0"
+			"ui5_enable"		"0"
+			"ui6_enable"		"0"
+			"viewmodel_offset_ads"							"0 -3 -0.55" //"0 -9 -0.78"
+			"zoom_fov"										"25"
+			"dof_zoom_nearDepthStart"						"8.491"
+			"dof_zoom_nearDepthEnd"							"12.945"
+			//threat settings
+			//"threat_scope_enabled"			"1"
+			//"threat_scope_bounds_tagname1"	"SCR_TR_ACGS"
+			//"threat_scope_bounds_tagname2"	"SCR_BL_ACGS"
+		}
+		threat_scope
+		{
+			"ui3_enable"		"0"
+			"ui4_enable"		"1"
+			"ui5_enable"		"0"
+			"ui6_enable"		"0"
+			"viewmodel_offset_ads"							"0 -3 -0.58" //"0 -9 -0.78"
+			"zoom_fov"										"35"
+			"dof_zoom_nearDepthStart"						"7.491"
+			"dof_zoom_nearDepthEnd"							"12.545"
+		}
+	}
+
+	//Acog
+	"ui3_enable"		"0"
+	"ui3_draw_cloaked"	"1"
+	UiData3
+	{
+		"ui"								"ui/acgs_redline"
+		"mesh"							"models/weapons/attachments/acgs_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+			ammo						weapon_ammo
+			clipSize						weapon_clipSize
+		}
+	}
+	//Threat
+	"ui4_enable"		"0"
+	"ui4_draw_cloaked"	"1"
+	UiData4
+	{
+		"ui"							"ui/cro_threat_front"
+		"mesh"					"models/weapons/attachments/cro_rui_upper"
+		Args
+		{
+			zoomFrac					player_zoomfrac
+		}
+	}
+	//Hcog
+	"ui5_enable"		"0"
+	"ui5_draw_cloaked"	"1"
+	UiData5
+	{
+		"ui"								"ui/vinson_sights"
+		"mesh"						"models/weapons/attachments/cqh_rui_upper"
+		Args
+		{
+			vis							player_zoomfrac
+		}
+	}
+}


### PR DESCRIPTION
Repurposed existing ui data to add functional hcog/acog/threat for wingman/wingman_n/shotgun_pistol
By default
- hcog - x2
- threat -x2
- acog - x3

Changes:
- added keyvalues/scripts/weapons/mp_weapon_shotgunpistol using base-pistol/projectile
- added keyvalues/scripts/weapons/mp_weapon_wingman_n  using base-pistol, !! base_projectile (condensed_gunpowder)
 causes crashes due to projectile velocity exceeding max sv value

Repurposed existing ui data to add functional oracle sight for sniper/dmr/doubletake
By default: oracle - x2 + threat